### PR TITLE
Use NAN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ logs
 results
 
 npm-debug.log
+node_modules/
+build/

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,8 @@
     {
       "target_name": "node_win_shortcut_bindings",
       "sources": [ "node_win_shortcut_bindings.cc"],
-      'libraries': [ '-lruntimeobject.lib','-lshlwapi.lib' ]
+      "include_dirs": [ "<!(node -e \"require('nan')\")" ],
+      "libraries": [ "-lruntimeobject.lib","-lshlwapi.lib" ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.2",
   "description": "Create windows shortcuts using node.js",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "nan": "^2.4.0"
+  },
   "devDependencies": {},
   "keywords": [
     "shortcut",
@@ -12,6 +14,8 @@
     "appid"
   ],
   "scripts": {
+    "install": "node-gyp rebuild",
+    "build": "node-gyp build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "winrt",
     "appid"
   ],
+  "os": [
+    "win32"
+  ],
   "scripts": {
     "install": "node-gyp rebuild",
     "build": "node-gyp build",


### PR DESCRIPTION
This PR reworks the module to use [NAN](https://github.com/nodejs/nan), to better abstract V8 internals. This fixes some build issues I was seeing on Windows 10.

This also fixes #2 by marking this package as Windows-only.
